### PR TITLE
Include compiled.h instead of src/compiled.h

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -62,7 +62,7 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-  GAP                    := ">= 4.7",
+  GAP                    := ">= 4.9",
   NeededOtherPackages    := [ ],
   SuggestedOtherPackages := [ ],
   ExternalConditions     := [ ],

--- a/src/4ti2gap.h
+++ b/src/4ti2gap.h
@@ -6,7 +6,7 @@
 #endif
 
 extern "C" {
-#include "src/compiled.h"
+#include "compiled.h" // GAP headers
 }
 
 #endif


### PR DESCRIPTION
This is beneficial for versions of GAP which are installed systemwide (via Debian, Ubuntu, Fedora, ... package managers), which currently have to create a fake `src` dir just for the sake of packages like this.

This requires GAP >= 4.9, so also require that. Since no tests are done
with older GAP versions, that seem like a good idea anyway?
