### PR TITLE
m4/find_gap.m4: balance 'checking for GAP architecture' msg

### DIFF
--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -55,6 +55,7 @@ AC_DEFUN([FIND_GAP],
   if test "x$GAParch" != "x"; then
     GAPARCH=$GAParch
   fi
+  AC_MSG_RESULT($GAPARCH)
 
   if test "x$GAPARCH" = "xUnknown" ; then
     echo ""


### PR DESCRIPTION
The conclusion to the check was not printed and hence now trailing
newline printed. So whatever configure message came next ended up
starting on the wrong line.
